### PR TITLE
npm publish 2015.2.21-10

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ exit $EXIT_CODE
 
 
 ## todo
+- delete __coverage__ init code in example.js
 - delete env var $npm_config_coverage_report_dir
 - add max-height option in shRunScreenCapture
 - create flamegraph from istanbul coverage

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ lightweight nodejs module that runs phantomjs browser-tests with coverage (via i
   if (typeof window === 'object') {
     // init local.utility2
     local.utility2 = window.utility2;
+    local.utility2.__coverage__ = local.utility2.__coverage__ || window.__coverage__;
     // init tests
     local._ajax_200_test = function (onError) {
       /*

--- a/README.md
+++ b/README.md
@@ -31,15 +31,14 @@ lightweight nodejs module that runs phantomjs browser-tests with coverage (via i
   on itself with coverage for both the browser and server
 
   instruction to programmatically test browser and server with coverage
-  1. create a clean app directory (e.g /tmp/app)
-  2. inside app directory, save this script as example.js
-  3. inside app directory, run the shell command:
+  1. save this script as example.js
+  2. run the shell command:
      $ npm install phantomjs-lite utility2 &&\
        node_modules/.bin/utility2 shRun shNpmTest example.js
 
   instruction to interactively test server on port 8080 without coverage
   1. save this script as example.js
-  2. run shell command:
+  2. run the shell command:
      $ npm install utility2 && npm_config_server_port=8080 node example.js
   3. interactively test server on http://localhost:8080
 */
@@ -227,8 +226,8 @@ shBuild() {
   if [ "$TRAVIS" ]
   then
     shRun shTestHeroku || return $?
-    # if number of commits > 1000, then squash older commits
-    shRun shGitBackupAndSquashAndPush 1000 > /dev/null || return $?
+    # if number of commits > 1024, then squash older commits
+    shRun shGitBackupAndSquashAndPush 1024 > /dev/null || return $?
   fi
 }
 # run build

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ lightweight nodejs module that runs phantomjs browser-tests with coverage (via i
     // init tests
     local._phantomTest_default_test = function (onError) {
       /*
-        this function will spawn phantomjs to test the test-webpage
+        this function will spawn phantomjs to test the test-page
       */
       local.utility2.phantomTest({
         url: 'http://localhost:' + process.env.npm_config_server_port +
@@ -213,7 +213,7 @@ exit $EXIT_CODE
 
 
 ## todo
-- add phantomjs tests for coverage
+- delete env var $npm_config_coverage_report_dir
 - add max-height option in shRunScreenCapture
 - create flamegraph from istanbul coverage
 - explicitly require slimerjs instead of auto-detecting it

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ this lightweight nodejs module will run phantomjs browser-tests with coverage (v
   if (typeof window === 'object') {
     // init local.utility2
     local.utility2 = window.utility2;
-    local.utility2.__coverage__ = local.utility2.__coverage__ || window.__coverage__;
     // init tests
     local._ajax_200_test = function (onError) {
       /*
@@ -144,7 +143,9 @@ this lightweight nodejs module will run phantomjs browser-tests with coverage (v
 ```
 #### output
 ![screen-capture](https://kaizhu256.github.io/node-utility2/build/screen-capture.testExampleJs.png)
+
 ![screen-capture](https://kaizhu256.github.io/node-utility2/build/screen-capture.testExampleJs.slimerjs.png)
+
 ![screen-capture](https://kaizhu256.github.io/node-utility2/build/screen-capture.testExampleJs.slimerjs._2Ftmp_2Fapp_2F.tmp_2Fbuild_2Fcoverage.html_2Fapp_2Fexample.js.html.png)
 
 
@@ -209,9 +210,8 @@ EXIT_CODE=$?
 if [ "$TRAVIS" ]
 then
   shBuildGithubUploadCleanup() {
-    # this function can be overriden to cleanup gh-pages
-    touch a00.txt || return $?
-    echo 'hello shBuildGithubUploadCleanup' || return $?
+    # this function will cleanup build-artifacts before uploading
+    return
   }
   # if number of commits > 16, then squash older commits
   COMMIT_LIMIT=16 shRun shBuildGithubUpload || exit $?
@@ -223,10 +223,7 @@ exit $EXIT_CODE
 
 
 ## todo
-- fix unsafe javascript warning
-- delete __coverage__ init code in example.js
 - delete env var $npm_config_coverage_report_dir
-- add max-height option in shRunScreenCapture
 - create flamegraph from istanbul coverage
 - explicitly require slimerjs instead of auto-detecting it
 - auto-generate help doc from README.md

--- a/README.md
+++ b/README.md
@@ -208,6 +208,11 @@ EXIT_CODE=$?
 # upload build-artifacts to github
 if [ "$TRAVIS" ]
 then
+  shBuildGithubUploadCleanup() {
+    # this function can be overriden to cleanup gh-pages
+    touch a00.txt || return $?
+    echo 'hello shBuildGithubUploadCleanup' || return $?
+  }
   # if number of commits > 16, then squash older commits
   COMMIT_LIMIT=16 shRun shBuildGithubUpload || exit $?
 fi
@@ -218,6 +223,7 @@ exit $EXIT_CODE
 
 
 ## todo
+- fix unsafe javascript warning
 - delete __coverage__ init code in example.js
 - delete env var $npm_config_coverage_report_dir
 - add max-height option in shRunScreenCapture

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ lightweight nodejs module that runs phantomjs browser-tests with coverage (via i
 [![build commit status](https://kaizhu256.github.io/node-utility2/build/build.badge.svg)](https://travis-ci.org/kaizhu256/node-utility2)
 
 | git-branch | test-server | test-report | coverage | build-artifacts |
-|:----------:|:-----------:|:-----------:|:---------:|:---------------:|
+|:----------:|:-----------:|:-----------:|:--------:|:---------------:|
 |[master](https://github.com/kaizhu256/node-utility2/tree/master) | [![heroku.com test-server](https://kaizhu256.github.io/node-utility2/heroku-logo.75x25.png)](https://hrku01-utility2-master.herokuapp.com?modeTest=1) | [![test-report](https://kaizhu256.github.io/node-utility2/build..master..travis-ci.org/test-report.badge.svg)](https://kaizhu256.github.io/node-utility2/build..master..travis-ci.org/test-report.html) | [![istanbul-lite coverage](https://kaizhu256.github.io/node-utility2/build..master..travis-ci.org/coverage.badge.svg)](https://kaizhu256.github.io/node-utility2/build..master..travis-ci.org/coverage.html/node-utility2/index.html) | [![build-artifacts](https://kaizhu256.github.io/node-utility2/glyphicons_144_folder_open.png)](https://github.com/kaizhu256/node-utility2/tree/gh-pages/build..master..travis-ci.org)|
 |[beta](https://github.com/kaizhu256/node-utility2/tree/beta) | [![heroku.com test-server](https://kaizhu256.github.io/node-utility2/heroku-logo.75x25.png)](https://hrku01-utility2-beta.herokuapp.com?modeTest=1) | [![test-report](https://kaizhu256.github.io/node-utility2/build..beta..travis-ci.org/test-report.badge.svg)](https://kaizhu256.github.io/node-utility2/build..beta..travis-ci.org/test-report.html) | [![istanbul-lite coverage](https://kaizhu256.github.io/node-utility2/build..beta..travis-ci.org/coverage.badge.svg)](https://kaizhu256.github.io/node-utility2/build..beta..travis-ci.org/coverage.html/node-utility2/index.html) | [![build-artifacts](https://kaizhu256.github.io/node-utility2/glyphicons_144_folder_open.png)](https://github.com/kaizhu256/node-utility2/tree/gh-pages/build..beta..travis-ci.org)|
 |[alpha](https://github.com/kaizhu256/node-utility2/tree/alpha) | [![heroku.com test-server](https://kaizhu256.github.io/node-utility2/heroku-logo.75x25.png)](https://hrku01-utility2-alpha.herokuapp.com?modeTest=1) | [![test-report](https://kaizhu256.github.io/node-utility2/build..alpha..travis-ci.org/test-report.badge.svg)](https://kaizhu256.github.io/node-utility2/build..alpha..travis-ci.org/test-report.html) | [![istanbul-lite coverage](https://kaizhu256.github.io/node-utility2/build..alpha..travis-ci.org/coverage.badge.svg)](https://kaizhu256.github.io/node-utility2/build..alpha..travis-ci.org/coverage.html/node-utility2/index.html) | [![build-artifacts](https://kaizhu256.github.io/node-utility2/glyphicons_144_folder_open.png)](https://github.com/kaizhu256/node-utility2/tree/gh-pages/build..alpha..travis-ci.org)|
@@ -22,6 +22,7 @@ lightweight nodejs module that runs phantomjs browser-tests with coverage (via i
 
 
 ## quickstart
+#### follow the instruction inside this script
 ```
 /*
   example.js
@@ -31,13 +32,13 @@ lightweight nodejs module that runs phantomjs browser-tests with coverage (via i
 
   instruction to programmatically test browser and server with coverage
   1. create a clean app directory (e.g /tmp/app)
-  2. inside app directory, save this js script as example.js
+  2. inside app directory, save this script as example.js
   3. inside app directory, run the shell command:
      $ npm install phantomjs-lite utility2 &&\
        node_modules/.bin/utility2 shRun shNpmTest example.js
 
   instruction to interactively test server on port 8080 without coverage
-  1. save this js script as example.js
+  1. save this script as example.js
   2. run shell command:
      $ npm install utility2 && npm_config_server_port=8080 node example.js
   3. interactively test server on http://localhost:8080
@@ -158,12 +159,17 @@ lightweight nodejs module that runs phantomjs browser-tests with coverage (via i
   return;
 }());
 ```
-#### output
+#### output from shell
 ![screen-capture](https://kaizhu256.github.io/node-utility2/build/screen-capture.testExampleJs.png)
-
+#### output from [phantomjs-lite](https://www.npmjs.com/package/phantomjs-lite)
 ![screen-capture](https://kaizhu256.github.io/node-utility2/build/screen-capture.testExampleJs.slimerjs.png)
-
+#### output from [istanbul-lite](https://www.npmjs.com/package/istanbul-lite)
 ![screen-capture](https://kaizhu256.github.io/node-utility2/build/screen-capture.testExampleJs.slimerjs._2Ftmp_2Fapp_2F.tmp_2Fbuild_2Fcoverage.html_2Fapp_2Fexample.js.html.png)
+
+
+
+## package-listing
+[![screen-capture](https://kaizhu256.github.io/node-utility2/build/screen-capture.gitLsTree.png)](https://github.com/kaizhu256/node-utility2)
 
 
 
@@ -173,12 +179,22 @@ lightweight nodejs module that runs phantomjs browser-tests with coverage (via i
 
 
 
-## package-listing
-[![screen-capture](https://kaizhu256.github.io/node-utility2/build/screen-capture.gitLsTree.png)](https://github.com/kaizhu256/node-utility2)
+## todo
+- delete env var $npm_config_coverage_report_dir
+- create flamegraph from istanbul coverage
+- explicitly require slimerjs instead of auto-detecting it
+- auto-generate help doc from README.md
+- add server stress test using phantomjs
+- minify /assets/utility2.js in production-mode
 
 
 
-## build-script
+## changelog of last 50 commits
+![screen-capture](https://kaizhu256.github.io/node-utility2/build/screen-capture.gitLog.png)
+
+
+
+## internal build-script
 ```
 # build.sh
 # this shell script runs the build process for this package
@@ -246,8 +262,7 @@ shBuildCleanup
 if [ "$TRAVIS" ]
 then
   shBuildGithubUploadCleanup() {
-    # this function will cleanup build-artifacts
-    # in local gh-pages repo before uploading
+    # this function will cleanup build-artifacts in local gh-pages repo
     return
   }
   # if number of commits > 16, then squash older commits
@@ -256,18 +271,3 @@ fi
 # exit with $EXIT_CODE
 exit $EXIT_CODE
 ```
-
-
-
-## todo
-- delete env var $npm_config_coverage_report_dir
-- create flamegraph from istanbul coverage
-- explicitly require slimerjs instead of auto-detecting it
-- auto-generate help doc from README.md
-- add server stress test using phantomjs
-- minify /assets/utility2.js in production-mode
-
-
-
-## changelog of last 50 commits
-![screen-capture](https://kaizhu256.github.io/node-utility2/build/screen-capture.gitLog.png)

--- a/README.md
+++ b/README.md
@@ -179,7 +179,6 @@ lightweight nodejs module that runs phantomjs browser-tests with coverage (via i
 
 
 ## todo
-- delete env var $npm_config_coverage_report_dir
 - create flamegraph from istanbul coverage
 - explicitly require slimerjs instead of auto-detecting it
 - auto-generate help doc from README.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 utility2 [![NPM](https://img.shields.io/npm/v/utility2.svg?style=flat-square)](https://www.npmjs.com/package/utility2)
 ========
-lightweight nodejs module that runs phantomjs browser-tests with coverage (via istanbul-lite and phantomjs-lite)
+this lightweight nodejs module will run phantomjs browser-tests with coverage (via istanbul-lite and phantomjs-lite)
 
 
 
@@ -145,6 +145,7 @@ lightweight nodejs module that runs phantomjs browser-tests with coverage (via i
 #### output
 ![screen-capture](https://kaizhu256.github.io/node-utility2/build/screen-capture.testExampleJs.png)
 ![screen-capture](https://kaizhu256.github.io/node-utility2/build/screen-capture.testExampleJs.slimerjs.png)
+![screen-capture](https://kaizhu256.github.io/node-utility2/build/screen-capture.testExampleJs.slimerjs._2Ftmp_2Fapp_2F.tmp_2Fbuild_2Fcoverage.html_2Fapp_2Fexample.js.html.png)
 
 
 
@@ -185,8 +186,11 @@ shBuild() {
   # test example script
   MODE_BUILD=testExampleJs shRunScreenCapture shTestScriptJs example.js ||\
     return $?
+  # screen-capture example.js coverage
+  MODE_BUILD=testExampleJs shRun shPhantomScreenCapture\
+    /tmp/app/.tmp/build/coverage.html/app/example.js.html
   # copy phantomjs screen-capture to $npm_package_dir_build
-  cp /tmp/app/.tmp/build/screen-capture.* $npm_package_dir_build || return $?
+  cp /tmp/app/.tmp/build/screen-capture.*.png $npm_package_dir_build || return $?
   # run npm test
   MODE_BUILD=npmTest shRunScreenCapture npm test || return $?
   # deploy to heroku

--- a/index.js
+++ b/index.js
@@ -1464,6 +1464,8 @@
         modeNext += 1;
         switch (modeNext) {
         case 1:
+          // init __coverage__
+          exports.__coverage__ = exports.global.__coverage__ || {};
           // init global error handling
           // http://phantomjs.org/api/phantom/handler/on-error.html
           exports.global.phantom.onError = onNext;
@@ -1548,16 +1550,16 @@
               // handle global_test_results passed as error
               // merge coverage
               exports.istanbulMerge(exports.__coverage__, data.coverage);
-              // save screen-capture
-              exports.page.render(exports.fileScreenCapture);
+              // merge test-report
+              exports.testMerge(exports.testReport, data.testReport);
               // save html-content
               exports.fs.write(exports.fileScreenCapture + '.html', exports.page.content);
+              // save screen-capture
+              exports.page.render(exports.fileScreenCapture);
               // integrate screen-capture into test-report
               data.testReport.testPlatformList[0].screenCaptureImg =
                 exports.fileScreenCapture.replace((/^.*\//), '');
-              // merge test-report
-              exports.testMerge(exports.testReport, data.testReport);
-              // write test-report
+              // save test-report
               exports.fs.write(exports.fileTestReport, JSON.stringify(exports.testReport));
               // exit with number of tests failed as exit-code
               throw data.testReport.testsFailed;
@@ -1585,9 +1587,7 @@
           errorCaught = 1;
         }
         // save coverage before exiting
-        if (exports.__coverage__) {
-          exports.fs.write(exports.fileCoverage, JSON.stringify(exports.__coverage__));
-        }
+        exports.fs.write(exports.fileCoverage, JSON.stringify(exports.__coverage__));
         exports.exit(errorCaught);
       }
     };

--- a/index.js
+++ b/index.js
@@ -576,7 +576,7 @@
           // notify saucelabs of test results
           // https://docs.saucelabs.com/reference/rest-api/#js-unit-testing
           exports.global.global_test_results = {
-            coverage: exports.__coverage__,
+            coverage: exports.global.__coverage__,
             failed: exports.testReport.testsFailed,
             testReport: exports.testReport
           };
@@ -1019,7 +1019,7 @@
       // read options.data from options.file and comment out shebang
       options.data = exports.fs.readFileSync(options.file, 'utf8').replace((/^#!/), '//#!');
       // if coverage-mode is enabled, then cover options.data
-      if (exports.__coverage__ &&
+      if (exports.global.__coverage__ &&
           options.coverage && options.coverage === exports.envDict.npm_package_name) {
         options.data = exports.istanbulCover(options.data, options.file);
       }
@@ -1125,7 +1125,7 @@
               require('phantomjs-lite').__dirname + '/' + options.argv0,
               [
                 // coverage-hack - cover utility2.js
-                exports.__coverage__ && exports.envDict.npm_package_name === 'utility2' ?
+                exports.global.__coverage__ && exports.envDict.npm_package_name === 'utility2' ?
                     exports.envDict.npm_package_dir_tmp + '/covered.utility2.js'
                   : __dirname + '/index.js',
                 encodeURIComponent(JSON.stringify(options))
@@ -1150,7 +1150,7 @@
               if (data) {
                 // merge coverage
                 if (ii === 0) {
-                  exports.istanbulMerge(exports.__coverage__, data);
+                  exports.istanbulMerge(exports.global.__coverage__, data);
                 // merge test-report
                 } else if (options.modePhantom === 'testUrl' && !options.modeErrorIgnore) {
                   exports.testMerge(exports.testReport, data);
@@ -1379,7 +1379,7 @@
         file: __filename
       });
       // save covered utility2.js to fs
-      if (exports.__coverage__ && exports.envDict.npm_package_name === 'utility2') {
+      if (exports.global.__coverage__ && exports.envDict.npm_package_name === 'utility2') {
         exports.fs.writeFileSync(
           exports.envDict.npm_package_dir_tmp + '/covered.utility2.js',
           exports.fileCacheDict['/assets/utility2.js'].data
@@ -1465,7 +1465,7 @@
         switch (modeNext) {
         case 1:
           // init __coverage__
-          exports.__coverage__ = exports.global.__coverage__ || {};
+          exports.global.__coverage__ = exports.global.__coverage__ || {};
           // init global error handling
           // http://phantomjs.org/api/phantom/handler/on-error.html
           exports.global.phantom.onError = onNext;
@@ -1549,7 +1549,7 @@
             if (data) {
               // handle global_test_results passed as error
               // merge coverage
-              exports.istanbulMerge(exports.__coverage__, data.coverage);
+              exports.istanbulMerge(exports.global.__coverage__, data.coverage);
               // merge test-report
               exports.testMerge(exports.testReport, data.testReport);
               // save html-content
@@ -1587,7 +1587,7 @@
           errorCaught = 1;
         }
         // save coverage before exiting
-        exports.fs.write(exports.fileCoverage, JSON.stringify(exports.__coverage__));
+        exports.fs.write(exports.fileCoverage, JSON.stringify(exports.global.__coverage__));
         exports.exit(errorCaught);
       }
     };
@@ -1709,7 +1709,6 @@
       // return arg for inspection
       return arg;
     };
-    exports.__coverage__ = exports.__coverage__ || exports.global.__coverage__;
     exports.errorDefault = new Error('default error');
     exports.testPlatform = {
       name: exports.modeJs === 'browser' ? 'browser - ' +

--- a/index.js
+++ b/index.js
@@ -22,11 +22,13 @@
       if (!passed) {
         throw new Error(
           // if message is a string, then leave it as is
-          typeof message === 'string' ? message
+          typeof message === 'string'
+            ? message
             // if message is an Error object, then get its stack-trace
-            : message instanceof Error ? exports.errorStack(message)
-              // else JSON.stringify message
-              : JSON.stringify(message)
+            : message instanceof Error
+            ? exports.errorStack(message)
+            // else JSON.stringify message
+            : JSON.stringify(message)
         );
       }
     };
@@ -111,8 +113,8 @@
         return JSON.stringify(value);
       };
       value = JSON.stringify(value);
-      return typeof value === 'string' ?
-          JSON.stringify(JSON.parse(stringifyOrdered(JSON.parse(value))), replacer, space)
+      return typeof value === 'string'
+        ? JSON.stringify(JSON.parse(stringifyOrdered(JSON.parse(value))), replacer, space)
         : value;
     };
 
@@ -416,9 +418,11 @@
           }
         });
         // update testPlatform.status
-        testPlatform.status = testPlatform.testsFailed ? 'failed'
-          : testPlatform.testsPending ? 'pending'
-            : 'passed';
+        testPlatform.status = testPlatform.testsFailed
+          ? 'failed'
+          : testPlatform.testsPending
+          ? 'pending'
+          : 'passed';
         // sort testCaseList by status and name
         testPlatform.testCaseList.sort(function (arg1, arg2) {
           arg1 = arg1.status.replace('passed', 'z') + arg1.name.toLowerCase();
@@ -469,8 +473,8 @@
               errorStackList: errorStackList,
               // security - sanitize '<' in text
               name: String(testPlatform.name).replace((/</g), '&lt;'),
-              screenCapture: testPlatform.screenCaptureImg ?
-                  '<a class="testReportPlatformScreenCaptureA" href="' +
+              screenCapture: testPlatform.screenCaptureImg
+                ? '<a class="testReportPlatformScreenCaptureA" href="' +
                   testPlatform.screenCaptureImg + '">' +
                   '<img class="testReportPlatformScreenCaptureImg" src="' +
                   testPlatform.screenCaptureImg + '">' +
@@ -496,7 +500,8 @@
               testPlatformNumber: ii + 1
             });
           }),
-          testsFailedClass: testReport.testsFailed ? 'testReportTestFailed'
+          testsFailedClass: testReport.testsFailed
+            ? 'testReportTestFailed'
             : 'testReportTestPassed'
         }),
         'undefined'
@@ -956,9 +961,11 @@
           options.headers = options.headers || {};
           // init Content-Length header
           options.headers['Content-Length'] =
-            typeof options.data === 'string' ? Buffer.byteLength(options.data)
-            : Buffer.isBuffer(options.data) ? options.data.length
-              : 0;
+            typeof options.data === 'string'
+            ? Buffer.byteLength(options.data)
+            : Buffer.isBuffer(options.data)
+            ? options.data.length
+            : 0;
           // make http request
           request = (urlParsed.protocol === 'https:' ? exports.https : exports.http)
             .request(options, onNext)
@@ -1125,8 +1132,8 @@
               require('phantomjs-lite').__dirname + '/' + options.argv0,
               [
                 // coverage-hack - cover utility2.js
-                exports.global.__coverage__ && exports.envDict.npm_package_name === 'utility2' ?
-                    exports.envDict.npm_package_dir_tmp + '/covered.utility2.js'
+                exports.global.__coverage__ && exports.envDict.npm_package_name === 'utility2'
+                  ? exports.envDict.npm_package_dir_tmp + '/covered.utility2.js'
                   : __dirname + '/index.js',
                 encodeURIComponent(JSON.stringify(options))
               ],
@@ -1481,32 +1488,34 @@
           }
           // set timeout for phantom
           exports.onTimeout(exports.onErrorExit, exports.timeoutDefault, exports.url);
-          // test phantom internal-error handling behavior
-          if (exports.modePhantom === 'testPhantomInternalError') {
-            exports.testMock([
-              [exports, {
-                exit: exports.nop
-              }]
-            ], onNext, function (onError) {
-              // test trace-less error handling behavior
-              onNext('error', null);
-              // test function and sourceUrl trace error handling behavior
-              onNext('error', [{
-                function: true,
-                sourceUrl: true
-              }]);
-              // test error handling behavior
-              onError(exports.errorDefault);
-            });
-          }
+          //!! // test phantom internal-error handling behavior
+          //!! if (exports.modePhantom === 'testPhantomInternalError') {
+            //!! exports.testMock([
+              //!! [exports, {
+                //!! exit: exports.nop
+              //!! }]
+            //!! ], onNext, function (onError) {
+              //!! // test trace-less error handling behavior
+              //!! onNext('error', null);
+              //!! // test function and sourceUrl trace error handling behavior
+              //!! onNext('error', [{
+                //!! function: true,
+                //!! sourceUrl: true
+              //!! }]);
+              //!! // test error handling behavior
+              //!! onError(exports.errorDefault);
+            //!! });
+          //!! }
           // init webpage
           exports.page = exports.webpage.create();
-          // init webpage's viewport-size
-          exports.page.viewportSize = exports.viewportSize || { height: 600, width: 800 };
-          // init webpage's error handling
+          // init webpage clipRect
+          exports.page.clipRect = { height: 600, left: 0, top: 0, width: 800 };
+          // init webpage viewportSize
+          exports.page.viewportSize = { height: 600, width: 800 };
+          // init webpage error handling
           // http://phantomjs.org/api/webpage/handler/on-error.html
           exports.page.onError = exports.global.phantom.onError;
-          // pipe webpage's console.log to stdout
+          // pipe webpage console.log to stdout
           exports.page.onConsoleMessage = function () {
             console.log.apply(console, arguments);
           };
@@ -1518,7 +1527,8 @@
           );
           break;
         case 2:
-          console.log(exports.argv0 + ' - open ' + (error === 'success' ? 'success' : 'fail') +
+          console.log(exports.argv0 + ' - open ' +
+            (error === 'success' ? 'success' : 'fail') +
             ' ' + exports.url);
           // screen-capture webpage after timeoutScreenCapture ms
           if (exports.modePhantom === 'screenCapture') {
@@ -1535,8 +1545,6 @@
           case 'screenCapture':
             // save screen-capture
             exports.page.render(exports.fileScreenCapture);
-            //!! // save html-content
-            //!! exports.fs.write(exports.fileScreenCapture + '.html', exports.page.content);
             console.log('created file://' + exports.fileScreenCapture);
             break;
           // handle test-report callback
@@ -1552,8 +1560,6 @@
               exports.istanbulMerge(exports.global.__coverage__, data.coverage);
               // merge test-report
               exports.testMerge(exports.testReport, data.testReport);
-              //!! // save html-content
-              //!! exports.fs.write(exports.fileScreenCapture + '.html', exports.page.content);
               // save screen-capture
               exports.page.render(exports.fileScreenCapture);
               // integrate screen-capture into test-report
@@ -1711,15 +1717,16 @@
     };
     exports.errorDefault = new Error('default error');
     exports.testPlatform = {
-      name: exports.modeJs === 'browser' ? 'browser - ' +
-        navigator.userAgent + ' - ' + new Date().toISOString() :
-          exports.modeJs === 'node' ? 'node - ' +
-            process.platform + ' ' + process.version + ' - ' + new Date().toISOString() :
-              (exports.global.slimer ? 'slimer - ' : 'phantom - ') +
-              exports.system.os.name + ' ' +
-              exports.global.phantom.version.major + '.' +
-              exports.global.phantom.version.minor + '.' +
-              exports.global.phantom.version.patch + ' - ' + new Date().toISOString(),
+      name: exports.modeJs === 'browser'
+        ? 'browser - ' + navigator.userAgent + ' - ' + new Date().toISOString()
+        : exports.modeJs === 'node'
+        ? 'node - ' +
+          process.platform + ' ' + process.version + ' - ' + new Date().toISOString()
+        : (exports.global.slimer ? 'slimer - ' : 'phantom - ') +
+          exports.system.os.name + ' ' +
+          exports.global.phantom.version.major + '.' +
+          exports.global.phantom.version.minor + '.' +
+          exports.global.phantom.version.patch + ' - ' + new Date().toISOString(),
       screenCaptureImg: exports.envDict.MODE_BUILD_SCREEN_CAPTURE,
       testCaseList: []
     };

--- a/index.js
+++ b/index.js
@@ -1145,6 +1145,7 @@
           options.exitCode = error;
           onParallel = exports.onParallel(onNext);
           onParallel.counter += 1;
+          // merge coverage and test-report
           [options.fileCoverage, options.fileTestReport].forEach(function (file, ii) {
             onParallel.counter += 1;
             exports.fs.readFile(file, 'utf8', function (error, data) {

--- a/index.js
+++ b/index.js
@@ -1535,8 +1535,8 @@
           case 'screenCapture':
             // save screen-capture
             exports.page.render(exports.fileScreenCapture);
-            // save html-content
-            exports.fs.write(exports.fileScreenCapture + '.html', exports.page.content);
+            //!! // save html-content
+            //!! exports.fs.write(exports.fileScreenCapture + '.html', exports.page.content);
             console.log('created file://' + exports.fileScreenCapture);
             break;
           // handle test-report callback
@@ -1552,8 +1552,8 @@
               exports.istanbulMerge(exports.global.__coverage__, data.coverage);
               // merge test-report
               exports.testMerge(exports.testReport, data.testReport);
-              // save html-content
-              exports.fs.write(exports.fileScreenCapture + '.html', exports.page.content);
+              //!! // save html-content
+              //!! exports.fs.write(exports.fileScreenCapture + '.html', exports.page.content);
               // save screen-capture
               exports.page.render(exports.fileScreenCapture);
               // integrate screen-capture into test-report

--- a/index.sh
+++ b/index.sh
@@ -52,6 +52,8 @@ shBuildGithubUpload() {
   git clone git@github.com:$GITHUB_REPO.git\
     --branch=gh-pages --single-branch $npm_package_dir_tmp/gh-pages || return $?
   cd $npm_package_dir_tmp/gh-pages || return $?
+  # uncomment the line below to cleanup build dir
+  rm -fr build || return $?
   # copy build-artifacts to gh-pages
   cp -a $npm_package_dir_build . || return $?
   local DIR=build..$CI_BRANCH..$CI_HOST || return $?
@@ -382,7 +384,9 @@ shPhantomTest() {
   fi
   node -e "var local;
     local = require('$DIRNAME');
-    local.testReport = require('$npm_package_dir_build/test-report.json');
+    if ('$MODE_PHANTOM' === 'testUrl') {
+      local.testReport = require('$npm_package_dir_build/test-report.json');
+    }
     local.phantomTest({
       modePhantom: '$MODE_PHANTOM',
       timeoutDefault: $TIMEOUT_DEFAULT,

--- a/index.sh
+++ b/index.sh
@@ -34,15 +34,6 @@ shBuildGithubUpload() {
   # this function will upload build-artifacts to github
   shBuildPrint githubUpload\
     "uploading build-artifacts to git@github.com:$GITHUB_REPO.git ..." || return $?
-  # add black border around phantomjs screen-capture
-  local FILE_LIST="$(ls\
-    $npm_package_dir_build/screen-capture.*.phantomjs*.png\
-    $npm_package_dir_build/screen-capture.*.slimerjs*.png\
-    2>/dev/null)" || return $?
-  if [ "$FILE_LIST" ] && (mogrify --version > /dev/null 2>&1)
-  then
-    printf "$FILE_LIST" | xargs -n 1 mogrify -frame 1 -mattecolor black || return $?
-  fi
   if [ ! "$CI_BRANCH" ] || [ ! "$GIT_SSH_KEY" ] || [ "$MODE_OFFLINE" ]
   then
     return

--- a/index.sh
+++ b/index.sh
@@ -256,7 +256,6 @@ shInit() {
 shIstanbulCover() {
   # this function will run the command $@ with istanbul coverage
   npm_config_coverage_dir="$npm_package_dir_build/coverage.html"\
-  npm_config_coverage_report_dir="$npm_package_dir_build/coverage.html"\
     $ISTANBUL cover $@ || return $?
 }
 
@@ -278,7 +277,6 @@ shIstanbulReport() {
   fi
   # 2. create $npm_package_dir_build/coverage.html
   npm_config_coverage_dir="$npm_package_dir_build/coverage.html"\
-  npm_config_coverage_report_dir="$npm_package_dir_build/coverage.html"\
     $ISTANBUL report || return $?
 }
 

--- a/index.sh
+++ b/index.sh
@@ -52,14 +52,14 @@ shBuildGithubUpload() {
   git clone git@github.com:$GITHUB_REPO.git\
     --branch=gh-pages --single-branch $npm_package_dir_tmp/gh-pages || return $?
   cd $npm_package_dir_tmp/gh-pages || return $?
-  # uncomment the line below to cleanup build dir
-  rm -fr build || return $?
   # copy build-artifacts to gh-pages
   cp -a $npm_package_dir_build . || return $?
   local DIR=build..$CI_BRANCH..$CI_HOST || return $?
   rm -fr $DIR && cp -a $npm_package_dir_build $DIR || return $?
   # init .git/config
   printf "\n[user]\nname=nobody\nemail=nobody" >> .git/config || return $?
+  # cleanup dir
+  shBuildGithubUploadCleanup || return $?
   # update gh-pages
   git add -A || return $?
   git commit -am "[skip ci] update gh-pages" || return $?
@@ -546,7 +546,9 @@ shTestScriptJs() {
       require('fs').writeFileSync(
         '$FILE',
         // preserve lineno
-        data.slice(0, match0.index).replace((/.*/g), '') + match0.slice(4, -4)
+        ('$MODE_LINENO_PRESERVE'
+          ? data.slice(0, index).replace((/.*/g), '') + '\n\n'
+          : '') + match0.slice(5, -4)
       );
     }
   );" || return $?
@@ -593,7 +595,7 @@ shTestScriptSh() {
       require('fs').writeFileSync(
         '$FILE',
         // preserve lineno
-        data.slice(0, match0.index).replace((/.*/g), '') + match0.slice(4, -4)
+        data.slice(0, match0.index).replace((/.*/g), '') + '\n\n' + match0.slice(5, -4)
       );
     }
   );" || return $?

--- a/index.sh
+++ b/index.sh
@@ -262,6 +262,7 @@ shInit() {
 
 shIstanbulCover() {
   # this function will run the command $@ with istanbul coverage
+  npm_config_coverage_dir="$npm_package_dir_build/coverage.html"\
   npm_config_coverage_report_dir="$npm_package_dir_build/coverage.html"\
     $ISTANBUL cover $@ || return $?
 }
@@ -283,6 +284,7 @@ shIstanbulReport() {
     );" || return $?
   fi
   # 2. create $npm_package_dir_build/coverage.html
+  npm_config_coverage_dir="$npm_package_dir_build/coverage.html"\
   npm_config_coverage_report_dir="$npm_package_dir_build/coverage.html"\
     $ISTANBUL report || return $?
 }

--- a/index.sh
+++ b/index.sh
@@ -325,6 +325,7 @@ shNpmTest() {
     percent = Math.floor((100000 * percent[0] / percent[1] + 5) / 10) / 100;
     require('fs').writeFileSync(
       '$npm_package_dir_build/coverage.badge.svg',
+      // https://img.shields.io/badge/coverage-100.0%-00dd00.svg?style=flat
       '"'<svg xmlns="http://www.w3.org/2000/svg" width="117" height="20"><linearGradient id="a" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><rect rx="0" width="117" height="20" fill="#555"/><rect rx="0" x="63" width="54" height="20" fill="#0d0"/><path fill="#0d0" d="M63 0h4v20h-4z"/><rect rx="0" width="117" height="20" fill="url(#a)"/><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"><text x="32.5" y="15" fill="#010101" fill-opacity=".3">coverage</text><text x="32.5" y="14">coverage</text><text x="89" y="15" fill="#010101" fill-opacity=".3">100.0%</text><text x="89" y="14">100.0%</text></g></svg>'"'
         // edit coverage badge percent
         .replace((/100.0/g), percent)
@@ -519,7 +520,7 @@ shTestHeroku() {
 }
 
 shTestScriptJs() {
-  # this function will test the js script $FILE in README.md
+  # this function will test the javascript script $FILE in README.md
   local FILE=$1 || return $?
   shBuildPrint $MODE_BUILD "testing $FILE ..." || return $?
   if [ ! "$MODE_OFFLINE" ]
@@ -569,7 +570,7 @@ shTestScriptJs() {
 }
 
 shTestScriptSh() {
-  # this function will test the sh script $FILE in README.md
+  # this function will test the shell script $FILE in README.md
   local FILE=$1 || return $?
   local FILE_BASENAME=$(node -e "console.log(require('path').basename('$FILE'));") || return $?
   shBuildPrint $MODE_BUILD "testing $FILE ..." || return $?
@@ -586,7 +587,7 @@ shTestScriptSh() {
       require('fs').writeFileSync(
         '$FILE',
         // preserve lineno
-        data.slice(0, match0.index).replace((/.*/g), '') + '\n\n' + match0.slice(5, -4)
+        data.slice(0, index).replace((/.*/g), '') + '\n\n' + match0.slice(5, -4)
       );
     }
   );" || return $?

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "phantomjs-lite": "^2015.1.4-102"
   },
-  "description": "this lightweight nodejs module will run phantomjs browser-tests with coverage (via istanbul-lite and phantomjs-lite)",
+  "description": "lightweight nodejs module that runs phantomjs browser-tests with coverage (via istanbul-lite and phantomjs-lite)",
   "engines": { "node": "0.10" },
   "keywords": [
     "browser",

--- a/package.json
+++ b/package.json
@@ -41,5 +41,5 @@
     "start": "npm_config_mode_auto_restart=1 ./index.sh shRun node test.js",
     "test": "npm_config_mode_auto_restart=1 npm_config_mode_auto_restart_child=1 ./index.sh shRun shNpmTest test.js"
   },
-  "version": "2015.2.20-11"
+  "version": "2015.2.20-12"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "kai zhu <kaizhu256@gmail.com>",
   "bin": { "utility2" : "index.sh" },
   "dependencies": {
-    "istanbul-lite": "2015.2.21-10",
+    "istanbul-lite": "2015.2.21-11",
     "jslint-lite": "2015.2.18-10"
   },
   "devDependencies": {
@@ -41,5 +41,5 @@
     "start": "npm_config_mode_auto_restart=1 ./index.sh shRun node test.js",
     "test": "npm_config_mode_auto_restart=1 npm_config_mode_auto_restart_child=1 ./index.sh shRun shNpmTest test.js"
   },
-  "version": "2015.2.21-10"
+  "version": "2015.2.21-11"
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "phantomjs-lite": "^2015.1.4-102"
   },
-  "description": "lightweight nodejs module that runs phantomjs browser-tests with coverage (via istanbul-lite and phantomjs-lite",
+  "description": "this lightweight nodejs module will run phantomjs browser-tests with coverage (via istanbul-lite and phantomjs-lite)",
   "engines": { "node": "0.10" },
   "keywords": [
     "browser",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "kai zhu <kaizhu256@gmail.com>",
   "bin": { "utility2" : "index.sh" },
   "dependencies": {
-    "istanbul-lite": "2015.2.19-10",
+    "istanbul-lite": "2015.2.21-10",
     "jslint-lite": "2015.2.18-10"
   },
   "devDependencies": {
@@ -41,5 +41,5 @@
     "start": "npm_config_mode_auto_restart=1 ./index.sh shRun node test.js",
     "test": "npm_config_mode_auto_restart=1 npm_config_mode_auto_restart_child=1 ./index.sh shRun shNpmTest test.js"
   },
-  "version": "2015.2.20-12"
+  "version": "2015.2.21-10"
 }

--- a/package.json
+++ b/package.json
@@ -41,5 +41,5 @@
     "start": "npm_config_mode_auto_restart=1 ./index.sh shRun node test.js",
     "test": "npm_config_mode_auto_restart=1 npm_config_mode_auto_restart_child=1 ./index.sh shRun shNpmTest test.js"
   },
-  "version": "2015.2.20-10"
+  "version": "2015.2.20-11"
 }

--- a/test.js
+++ b/test.js
@@ -537,11 +537,11 @@
         url: 'http://localhost:' + exports.envDict.npm_config_server_port +
           // test script-error handling behavior
           '/test/script-error.html'
-      }, {
-        modeErrorIgnore: true,
-        // test phantom internal-error handling behavior
-        modePhantom: 'testPhantomInternalError',
-        url: 'http://localhost:' + exports.envDict.npm_config_server_port
+      //!! }, {
+        //!! modeErrorIgnore: true,
+        //!! // test phantom internal-error handling behavior
+        //!! modePhantom: 'testPhantomInternalError',
+        //!! url: 'http://localhost:' + exports.envDict.npm_config_server_port
       }].forEach(function (options) {
         onParallel.counter += 1;
         exports.phantomTest(options, function (error) {

--- a/test.js
+++ b/test.js
@@ -537,11 +537,6 @@
         url: 'http://localhost:' + exports.envDict.npm_config_server_port +
           // test script-error handling behavior
           '/test/script-error.html'
-      //!! }, {
-        //!! modeErrorIgnore: true,
-        //!! // test phantom internal-error handling behavior
-        //!! modePhantom: 'testPhantomInternalError',
-        //!! url: 'http://localhost:' + exports.envDict.npm_config_server_port
       }].forEach(function (options) {
         onParallel.counter += 1;
         exports.phantomTest(options, function (error) {


### PR DESCRIPTION
- npm publish 2015.2.21-11
- update npm dependency to istanbul-lite@2015.2.21-11
- replace env var $npm_config_coverage_report_dir with $npm_config_coverage_report_dir
- fix unsafe javascript warning
- delete **coverage** init code in example.js
- make lineno preservation in shTestExampleJs optional
- fix phantomScreenCapture bug
- add screen-capture of example.js coverage in README.md
- replace exports.**coverage** with exports.global.**coverage**
